### PR TITLE
Füge Stildatenbank "Change Detection" hinzu

### DIFF
--- a/styles/change_detection/layerstil_cd_punkt_gruen.qml
+++ b/styles/change_detection/layerstil_cd_punkt_gruen.qml
@@ -1,59 +1,185 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis styleCategories="Symbology" version="3.18.1-Zürich">
-  <renderer-v2 enableorderby="0" symbollevels="0" type="singleSymbol" forceraster="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="0">
+      <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="0" type="marker">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+        <layer class="SimpleMarker" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="angle"/>
-            <Option type="QString" value="100,254,46,255" name="color"/>
-            <Option type="QString" value="1" name="horizontal_anchor_point"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="circle" name="name"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="100,254,46,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0" name="outline_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="diameter" name="scale_method"/>
-            <Option type="QString" value="2" name="size"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-            <Option type="QString" value="MM" name="size_unit"/>
-            <Option type="QString" value="1" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="100,254,46,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="circle" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="100,254,46,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="2" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
-          <prop k="angle" v="0"/>
-          <prop k="color" v="100,254,46,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="100,254,46,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="2"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+          <prop v="0" k="angle"/>
+          <prop v="100,254,46,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="100,254,46,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <effect enabled="1" type="effectStack">
+            <effect type="dropShadow">
+              <Option type="Map">
+                <Option value="13" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="135" name="offset_angle" type="QString"/>
+                <Option value="2" name="offset_distance" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="outerGlow">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="0.7935" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0" name="color_type" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="1" name="enabled" type="QString"/>
+                <Option value="0.5" name="opacity" type="QString"/>
+                <Option value="100,254,46,255" name="single_color" type="QString"/>
+                <Option value="3" name="spread" type="QString"/>
+                <Option value="MM" name="spread_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="0.7935" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0" k="color_type"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="1" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="100,254,46,255" k="single_color"/>
+              <prop v="3" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+            <effect type="drawSource">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="1" name="enabled" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="1" k="enabled"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerShadow">
+              <Option type="Map">
+                <Option value="13" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="135" name="offset_angle" type="QString"/>
+                <Option value="2" name="offset_distance" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerGlow">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0" name="color_type" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="0.5" name="opacity" type="QString"/>
+                <Option value="255,255,255,255" name="single_color" type="QString"/>
+                <Option value="2" name="spread" type="QString"/>
+                <Option value="MM" name="spread_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0" k="color_type"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="255,255,255,255" k="single_color"/>
+              <prop v="2" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+          </effect>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -61,146 +187,146 @@
     </symbols>
     <rotation/>
     <sizescale/>
-    <effect enabled="1" type="effectStack">
+    <effect enabled="0" type="effectStack">
       <effect type="dropShadow">
         <Option type="Map">
-          <Option type="QString" value="13" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,0,255" name="color"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="135" name="offset_angle"/>
-          <Option type="QString" value="2" name="offset_distance"/>
-          <Option type="QString" value="MM" name="offset_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_unit_scale"/>
-          <Option type="QString" value="1" name="opacity"/>
+          <Option value="13" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,0,255" name="color" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="135" name="offset_angle" type="QString"/>
+          <Option value="2" name="offset_distance" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+          <Option value="1" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="13"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color" v="0,0,0,255"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="offset_angle" v="135"/>
-        <prop k="offset_distance" v="2"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="opacity" v="1"/>
+        <prop v="13" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,0,255" k="color"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="135" k="offset_angle"/>
+        <prop v="2" k="offset_distance"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+        <prop v="1" k="opacity"/>
       </effect>
       <effect type="outerGlow">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="0.8" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,255,255" name="color1"/>
-          <Option type="QString" value="0,255,0,255" name="color2"/>
-          <Option type="QString" value="0" name="color_type"/>
-          <Option type="QString" value="0" name="discrete"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="1" name="enabled"/>
-          <Option type="QString" value="0.5" name="opacity"/>
-          <Option type="QString" value="gradient" name="rampType"/>
-          <Option type="QString" value="100,254,46,255" name="single_color"/>
-          <Option type="QString" value="3" name="spread"/>
-          <Option type="QString" value="MM" name="spread_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="spread_unit_scale"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="0.8" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,255,255" name="color1" type="QString"/>
+          <Option value="0,255,0,255" name="color2" type="QString"/>
+          <Option value="0" name="color_type" type="QString"/>
+          <Option value="0" name="discrete" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="1" name="enabled" type="QString"/>
+          <Option value="0.5" name="opacity" type="QString"/>
+          <Option value="gradient" name="rampType" type="QString"/>
+          <Option value="100,254,46,255" name="single_color" type="QString"/>
+          <Option value="3" name="spread" type="QString"/>
+          <Option value="MM" name="spread_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="blur_level" v="0.8"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color1" v="0,0,255,255"/>
-        <prop k="color2" v="0,255,0,255"/>
-        <prop k="color_type" v="0"/>
-        <prop k="discrete" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="1"/>
-        <prop k="opacity" v="0.5"/>
-        <prop k="rampType" v="gradient"/>
-        <prop k="single_color" v="100,254,46,255"/>
-        <prop k="spread" v="3"/>
-        <prop k="spread_unit" v="MM"/>
-        <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="0.8" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,255,255" k="color1"/>
+        <prop v="0,255,0,255" k="color2"/>
+        <prop v="0" k="color_type"/>
+        <prop v="0" k="discrete"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="0.5" k="opacity"/>
+        <prop v="gradient" k="rampType"/>
+        <prop v="100,254,46,255" k="single_color"/>
+        <prop v="3" k="spread"/>
+        <prop v="MM" k="spread_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
       </effect>
       <effect type="drawSource">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="1" name="enabled"/>
-          <Option type="QString" value="1" name="opacity"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="1" name="enabled" type="QString"/>
+          <Option value="1" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="1"/>
-        <prop k="opacity" v="1"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="1" k="opacity"/>
       </effect>
       <effect type="innerShadow">
         <Option type="Map">
-          <Option type="QString" value="13" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,0,255" name="color"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="135" name="offset_angle"/>
-          <Option type="QString" value="2" name="offset_distance"/>
-          <Option type="QString" value="MM" name="offset_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_unit_scale"/>
-          <Option type="QString" value="0.146" name="opacity"/>
+          <Option value="13" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,0,255" name="color" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="135" name="offset_angle" type="QString"/>
+          <Option value="2" name="offset_distance" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+          <Option value="0.146" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="13"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color" v="0,0,0,255"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="offset_angle" v="135"/>
-        <prop k="offset_distance" v="2"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="opacity" v="0.146"/>
+        <prop v="13" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,0,255" k="color"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="135" k="offset_angle"/>
+        <prop v="2" k="offset_distance"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+        <prop v="0.146" k="opacity"/>
       </effect>
       <effect type="innerGlow">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,255,255" name="color1"/>
-          <Option type="QString" value="0,255,0,255" name="color2"/>
-          <Option type="QString" value="0" name="color_type"/>
-          <Option type="QString" value="0" name="discrete"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="0.5" name="opacity"/>
-          <Option type="QString" value="gradient" name="rampType"/>
-          <Option type="QString" value="255,255,255,255" name="single_color"/>
-          <Option type="QString" value="2" name="spread"/>
-          <Option type="QString" value="MM" name="spread_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="spread_unit_scale"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,255,255" name="color1" type="QString"/>
+          <Option value="0,255,0,255" name="color2" type="QString"/>
+          <Option value="0" name="color_type" type="QString"/>
+          <Option value="0" name="discrete" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="0.5" name="opacity" type="QString"/>
+          <Option value="gradient" name="rampType" type="QString"/>
+          <Option value="255,255,255,255" name="single_color" type="QString"/>
+          <Option value="2" name="spread" type="QString"/>
+          <Option value="MM" name="spread_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color1" v="0,0,255,255"/>
-        <prop k="color2" v="0,255,0,255"/>
-        <prop k="color_type" v="0"/>
-        <prop k="discrete" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="opacity" v="0.5"/>
-        <prop k="rampType" v="gradient"/>
-        <prop k="single_color" v="255,255,255,255"/>
-        <prop k="spread" v="2"/>
-        <prop k="spread_unit" v="MM"/>
-        <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,255,255" k="color1"/>
+        <prop v="0,255,0,255" k="color2"/>
+        <prop v="0" k="color_type"/>
+        <prop v="0" k="discrete"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="0.5" k="opacity"/>
+        <prop v="gradient" k="rampType"/>
+        <prop v="255,255,255,255" k="single_color"/>
+        <prop v="2" k="spread"/>
+        <prop v="MM" k="spread_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
       </effect>
     </effect>
   </renderer-v2>

--- a/styles/change_detection/layerstil_cd_punkt_rot.qml
+++ b/styles/change_detection/layerstil_cd_punkt_rot.qml
@@ -1,59 +1,185 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis styleCategories="Symbology" version="3.18.1-Zürich">
-  <renderer-v2 enableorderby="0" symbollevels="0" type="singleSymbol" forceraster="0">
+  <renderer-v2 enableorderby="0" symbollevels="0" forceraster="0" type="singleSymbol">
     <symbols>
-      <symbol clip_to_extent="1" type="marker" force_rhr="0" alpha="1" name="0">
+      <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="0" type="marker">
         <data_defined_properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+        <layer class="SimpleMarker" locked="0" enabled="1" pass="0">
           <Option type="Map">
-            <Option type="QString" value="0" name="angle"/>
-            <Option type="QString" value="227,26,28,255" name="color"/>
-            <Option type="QString" value="1" name="horizontal_anchor_point"/>
-            <Option type="QString" value="bevel" name="joinstyle"/>
-            <Option type="QString" value="circle" name="name"/>
-            <Option type="QString" value="0,0" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="offset_unit"/>
-            <Option type="QString" value="227,26,28,255" name="outline_color"/>
-            <Option type="QString" value="solid" name="outline_style"/>
-            <Option type="QString" value="0" name="outline_width"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
-            <Option type="QString" value="MM" name="outline_width_unit"/>
-            <Option type="QString" value="diameter" name="scale_method"/>
-            <Option type="QString" value="2" name="size"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
-            <Option type="QString" value="MM" name="size_unit"/>
-            <Option type="QString" value="1" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="227,26,28,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="circle" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="227,26,28,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="2" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
-          <prop k="angle" v="0"/>
-          <prop k="color" v="227,26,28,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="227,26,28,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="2"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+          <prop v="0" k="angle"/>
+          <prop v="227,26,28,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="227,26,28,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <effect enabled="1" type="effectStack">
+            <effect type="dropShadow">
+              <Option type="Map">
+                <Option value="13" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="135" name="offset_angle" type="QString"/>
+                <Option value="2" name="offset_distance" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="outerGlow">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="0.8" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0" name="color_type" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="1" name="enabled" type="QString"/>
+                <Option value="0.5" name="opacity" type="QString"/>
+                <Option value="227,26,28,255" name="single_color" type="QString"/>
+                <Option value="3" name="spread" type="QString"/>
+                <Option value="MM" name="spread_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="0.8" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0" k="color_type"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="1" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="227,26,28,255" k="single_color"/>
+              <prop v="3" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+            <effect type="drawSource">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="1" name="enabled" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="1" k="enabled"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerShadow">
+              <Option type="Map">
+                <Option value="13" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="135" name="offset_angle" type="QString"/>
+                <Option value="2" name="offset_distance" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+                <Option value="1" name="opacity" type="QString"/>
+              </Option>
+              <prop v="13" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0,0,0,255" k="color"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="135" k="offset_angle"/>
+              <prop v="2" k="offset_distance"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+              <prop v="1" k="opacity"/>
+            </effect>
+            <effect type="innerGlow">
+              <Option type="Map">
+                <Option value="0" name="blend_mode" type="QString"/>
+                <Option value="2.645" name="blur_level" type="QString"/>
+                <Option value="MM" name="blur_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+                <Option value="0" name="color_type" type="QString"/>
+                <Option value="2" name="draw_mode" type="QString"/>
+                <Option value="0" name="enabled" type="QString"/>
+                <Option value="0.5" name="opacity" type="QString"/>
+                <Option value="255,255,255,255" name="single_color" type="QString"/>
+                <Option value="2" name="spread" type="QString"/>
+                <Option value="MM" name="spread_unit" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+              </Option>
+              <prop v="0" k="blend_mode"/>
+              <prop v="2.645" k="blur_level"/>
+              <prop v="MM" k="blur_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+              <prop v="0" k="color_type"/>
+              <prop v="2" k="draw_mode"/>
+              <prop v="0" k="enabled"/>
+              <prop v="0.5" k="opacity"/>
+              <prop v="255,255,255,255" k="single_color"/>
+              <prop v="2" k="spread"/>
+              <prop v="MM" k="spread_unit"/>
+              <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+            </effect>
+          </effect>
           <data_defined_properties>
             <Option type="Map">
-              <Option type="QString" value="" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -61,146 +187,146 @@
     </symbols>
     <rotation/>
     <sizescale/>
-    <effect enabled="1" type="effectStack">
+    <effect enabled="0" type="effectStack">
       <effect type="dropShadow">
         <Option type="Map">
-          <Option type="QString" value="13" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,0,255" name="color"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="135" name="offset_angle"/>
-          <Option type="QString" value="2" name="offset_distance"/>
-          <Option type="QString" value="MM" name="offset_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_unit_scale"/>
-          <Option type="QString" value="1" name="opacity"/>
+          <Option value="13" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,0,255" name="color" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="135" name="offset_angle" type="QString"/>
+          <Option value="2" name="offset_distance" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+          <Option value="1" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="13"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color" v="0,0,0,255"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="offset_angle" v="135"/>
-        <prop k="offset_distance" v="2"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="opacity" v="1"/>
+        <prop v="13" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,0,255" k="color"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="135" k="offset_angle"/>
+        <prop v="2" k="offset_distance"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+        <prop v="1" k="opacity"/>
       </effect>
       <effect type="outerGlow">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="0.8" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,255,255" name="color1"/>
-          <Option type="QString" value="0,255,0,255" name="color2"/>
-          <Option type="QString" value="0" name="color_type"/>
-          <Option type="QString" value="0" name="discrete"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="1" name="enabled"/>
-          <Option type="QString" value="0.5" name="opacity"/>
-          <Option type="QString" value="gradient" name="rampType"/>
-          <Option type="QString" value="227,26,28,255" name="single_color"/>
-          <Option type="QString" value="3" name="spread"/>
-          <Option type="QString" value="MM" name="spread_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="spread_unit_scale"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="0.8" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,255,255" name="color1" type="QString"/>
+          <Option value="0,255,0,255" name="color2" type="QString"/>
+          <Option value="0" name="color_type" type="QString"/>
+          <Option value="0" name="discrete" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="1" name="enabled" type="QString"/>
+          <Option value="0.5" name="opacity" type="QString"/>
+          <Option value="gradient" name="rampType" type="QString"/>
+          <Option value="227,26,28,255" name="single_color" type="QString"/>
+          <Option value="3" name="spread" type="QString"/>
+          <Option value="MM" name="spread_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="blur_level" v="0.8"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color1" v="0,0,255,255"/>
-        <prop k="color2" v="0,255,0,255"/>
-        <prop k="color_type" v="0"/>
-        <prop k="discrete" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="1"/>
-        <prop k="opacity" v="0.5"/>
-        <prop k="rampType" v="gradient"/>
-        <prop k="single_color" v="227,26,28,255"/>
-        <prop k="spread" v="3"/>
-        <prop k="spread_unit" v="MM"/>
-        <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="0.8" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,255,255" k="color1"/>
+        <prop v="0,255,0,255" k="color2"/>
+        <prop v="0" k="color_type"/>
+        <prop v="0" k="discrete"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="0.5" k="opacity"/>
+        <prop v="gradient" k="rampType"/>
+        <prop v="227,26,28,255" k="single_color"/>
+        <prop v="3" k="spread"/>
+        <prop v="MM" k="spread_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
       </effect>
       <effect type="drawSource">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="1" name="enabled"/>
-          <Option type="QString" value="1" name="opacity"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="1" name="enabled" type="QString"/>
+          <Option value="1" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="1"/>
-        <prop k="opacity" v="1"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="1" k="opacity"/>
       </effect>
       <effect type="innerShadow">
         <Option type="Map">
-          <Option type="QString" value="13" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,0,255" name="color"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="135" name="offset_angle"/>
-          <Option type="QString" value="2" name="offset_distance"/>
-          <Option type="QString" value="MM" name="offset_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_unit_scale"/>
-          <Option type="QString" value="0.146" name="opacity"/>
+          <Option value="13" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,0,255" name="color" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="135" name="offset_angle" type="QString"/>
+          <Option value="2" name="offset_distance" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+          <Option value="0.146" name="opacity" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="13"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color" v="0,0,0,255"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="offset_angle" v="135"/>
-        <prop k="offset_distance" v="2"/>
-        <prop k="offset_unit" v="MM"/>
-        <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="opacity" v="0.146"/>
+        <prop v="13" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,0,255" k="color"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="135" k="offset_angle"/>
+        <prop v="2" k="offset_distance"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+        <prop v="0.146" k="opacity"/>
       </effect>
       <effect type="innerGlow">
         <Option type="Map">
-          <Option type="QString" value="0" name="blend_mode"/>
-          <Option type="QString" value="2.645" name="blur_level"/>
-          <Option type="QString" value="MM" name="blur_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="blur_unit_scale"/>
-          <Option type="QString" value="0,0,255,255" name="color1"/>
-          <Option type="QString" value="0,255,0,255" name="color2"/>
-          <Option type="QString" value="0" name="color_type"/>
-          <Option type="QString" value="0" name="discrete"/>
-          <Option type="QString" value="2" name="draw_mode"/>
-          <Option type="QString" value="0" name="enabled"/>
-          <Option type="QString" value="0.5" name="opacity"/>
-          <Option type="QString" value="gradient" name="rampType"/>
-          <Option type="QString" value="255,255,255,255" name="single_color"/>
-          <Option type="QString" value="2" name="spread"/>
-          <Option type="QString" value="MM" name="spread_unit"/>
-          <Option type="QString" value="3x:0,0,0,0,0,0" name="spread_unit_scale"/>
+          <Option value="0" name="blend_mode" type="QString"/>
+          <Option value="2.645" name="blur_level" type="QString"/>
+          <Option value="MM" name="blur_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+          <Option value="0,0,255,255" name="color1" type="QString"/>
+          <Option value="0,255,0,255" name="color2" type="QString"/>
+          <Option value="0" name="color_type" type="QString"/>
+          <Option value="0" name="discrete" type="QString"/>
+          <Option value="2" name="draw_mode" type="QString"/>
+          <Option value="0" name="enabled" type="QString"/>
+          <Option value="0.5" name="opacity" type="QString"/>
+          <Option value="gradient" name="rampType" type="QString"/>
+          <Option value="255,255,255,255" name="single_color" type="QString"/>
+          <Option value="2" name="spread" type="QString"/>
+          <Option value="MM" name="spread_unit" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
         </Option>
-        <prop k="blend_mode" v="0"/>
-        <prop k="blur_level" v="2.645"/>
-        <prop k="blur_unit" v="MM"/>
-        <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"/>
-        <prop k="color1" v="0,0,255,255"/>
-        <prop k="color2" v="0,255,0,255"/>
-        <prop k="color_type" v="0"/>
-        <prop k="discrete" v="0"/>
-        <prop k="draw_mode" v="2"/>
-        <prop k="enabled" v="0"/>
-        <prop k="opacity" v="0.5"/>
-        <prop k="rampType" v="gradient"/>
-        <prop k="single_color" v="255,255,255,255"/>
-        <prop k="spread" v="2"/>
-        <prop k="spread_unit" v="MM"/>
-        <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop v="0" k="blend_mode"/>
+        <prop v="2.645" k="blur_level"/>
+        <prop v="MM" k="blur_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+        <prop v="0,0,255,255" k="color1"/>
+        <prop v="0,255,0,255" k="color2"/>
+        <prop v="0" k="color_type"/>
+        <prop v="0" k="discrete"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="0" k="enabled"/>
+        <prop v="0.5" k="opacity"/>
+        <prop v="gradient" k="rampType"/>
+        <prop v="255,255,255,255" k="single_color"/>
+        <prop v="2" k="spread"/>
+        <prop v="MM" k="spread_unit"/>
+        <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
       </effect>
     </effect>
   </renderer-v2>

--- a/styles/change_detection/stildatenbank_change_detection.xml
+++ b/styles/change_detection/stildatenbank_change_detection.xml
@@ -1,0 +1,1544 @@
+<!DOCTYPE qgis_style>
+<qgis_style version="2">
+  <symbols>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Linie grau" type="line">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="round" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="round" name="joinstyle" type="QString"/>
+          <Option value="110,110,110,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="round" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="round" k="joinstyle"/>
+        <prop v="110,110,110,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Linie grün" type="line">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="round" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="round" name="joinstyle" type="QString"/>
+          <Option value="100,254,46,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="round" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="round" k="joinstyle"/>
+        <prop v="100,254,46,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.7935" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="100,254,46,255" name="single_color" type="QString"/>
+              <Option value="3" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.7935" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="100,254,46,255" k="single_color"/>
+            <prop v="3" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="0.146" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="0.146" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.7935" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.386" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.7935" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.386" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Linie rot" type="line">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="round" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="round" name="joinstyle" type="QString"/>
+          <Option value="227,26,28,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="round" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="round" k="joinstyle"/>
+        <prop v="227,26,28,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.7935" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="239,41,41,255" name="single_color" type="QString"/>
+              <Option value="3" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.7935" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="239,41,41,255" k="single_color"/>
+            <prop v="3" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="0.146" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="0.146" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.7935" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.386" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.7935" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.386" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Polygon grau" type="fill">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="square" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="110,110,110,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="square" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="110,110,110,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <effect enabled="0" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="100,254,46,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="100,254,46,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="0.146" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="0.146" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Polygon grün" type="fill">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="square" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="100,254,46,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="square" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="100,254,46,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="100,254,46,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="100,254,46,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="0.146" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="0.146" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Polygon rot" type="fill">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleLine" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="align_dash_pattern" type="QString"/>
+          <Option value="square" name="capstyle" type="QString"/>
+          <Option value="5;2" name="customdash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+          <Option value="MM" name="customdash_unit" type="QString"/>
+          <Option value="0" name="dash_pattern_offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+          <Option value="0" name="draw_inside_polygon" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="227,26,28,255" name="line_color" type="QString"/>
+          <Option value="solid" name="line_style" type="QString"/>
+          <Option value="1.5" name="line_width" type="QString"/>
+          <Option value="MM" name="line_width_unit" type="QString"/>
+          <Option value="0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="0" name="ring_filter" type="QString"/>
+          <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+          <Option value="0" name="use_custom_dash" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
+        </Option>
+        <prop v="0" k="align_dash_pattern"/>
+        <prop v="square" k="capstyle"/>
+        <prop v="5;2" k="customdash"/>
+        <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+        <prop v="MM" k="customdash_unit"/>
+        <prop v="0" k="dash_pattern_offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+        <prop v="MM" k="dash_pattern_offset_unit"/>
+        <prop v="0" k="draw_inside_polygon"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="227,26,28,255" k="line_color"/>
+        <prop v="solid" k="line_style"/>
+        <prop v="1.5" k="line_width"/>
+        <prop v="MM" k="line_width_unit"/>
+        <prop v="0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="0" k="ring_filter"/>
+        <prop v="0" k="tweak_dash_pattern_on_corners"/>
+        <prop v="0" k="use_custom_dash"/>
+        <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="227,26,28,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="227,26,28,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="0.146" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="0.146" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Punkt grau" type="marker">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleMarker" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="angle" type="QString"/>
+          <Option value="110,110,110,255" name="color" type="QString"/>
+          <Option value="1" name="horizontal_anchor_point" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="circle" name="name" type="QString"/>
+          <Option value="0,0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="110,110,110,255" name="outline_color" type="QString"/>
+          <Option value="solid" name="outline_style" type="QString"/>
+          <Option value="0" name="outline_width" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+          <Option value="MM" name="outline_width_unit" type="QString"/>
+          <Option value="diameter" name="scale_method" type="QString"/>
+          <Option value="2" name="size" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+          <Option value="MM" name="size_unit" type="QString"/>
+          <Option value="1" name="vertical_anchor_point" type="QString"/>
+        </Option>
+        <prop v="0" k="angle"/>
+        <prop v="110,110,110,255" k="color"/>
+        <prop v="1" k="horizontal_anchor_point"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="circle" k="name"/>
+        <prop v="0,0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="110,110,110,255" k="outline_color"/>
+        <prop v="solid" k="outline_style"/>
+        <prop v="0" k="outline_width"/>
+        <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+        <prop v="MM" k="outline_width_unit"/>
+        <prop v="diameter" k="scale_method"/>
+        <prop v="2" k="size"/>
+        <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+        <prop v="MM" k="size_unit"/>
+        <prop v="1" k="vertical_anchor_point"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Punkt grün" type="marker">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleMarker" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="angle" type="QString"/>
+          <Option value="100,254,46,255" name="color" type="QString"/>
+          <Option value="1" name="horizontal_anchor_point" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="circle" name="name" type="QString"/>
+          <Option value="0,0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="100,254,46,255" name="outline_color" type="QString"/>
+          <Option value="solid" name="outline_style" type="QString"/>
+          <Option value="0" name="outline_width" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+          <Option value="MM" name="outline_width_unit" type="QString"/>
+          <Option value="diameter" name="scale_method" type="QString"/>
+          <Option value="2" name="size" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+          <Option value="MM" name="size_unit" type="QString"/>
+          <Option value="1" name="vertical_anchor_point" type="QString"/>
+        </Option>
+        <prop v="0" k="angle"/>
+        <prop v="100,254,46,255" k="color"/>
+        <prop v="1" k="horizontal_anchor_point"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="circle" k="name"/>
+        <prop v="0,0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="100,254,46,255" k="outline_color"/>
+        <prop v="solid" k="outline_style"/>
+        <prop v="0" k="outline_width"/>
+        <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+        <prop v="MM" k="outline_width_unit"/>
+        <prop v="diameter" k="scale_method"/>
+        <prop v="2" k="size"/>
+        <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+        <prop v="MM" k="size_unit"/>
+        <prop v="1" k="vertical_anchor_point"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.7935" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="100,254,46,255" name="single_color" type="QString"/>
+              <Option value="3" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.7935" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="100,254,46,255" k="single_color"/>
+            <prop v="3" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol clip_to_extent="1" force_rhr="0" alpha="1" name="CD Punkt rot" type="marker">
+      <data_defined_properties>
+        <Option type="Map">
+          <Option value="" name="name" type="QString"/>
+          <Option name="properties"/>
+          <Option value="collection" name="type" type="QString"/>
+        </Option>
+      </data_defined_properties>
+      <layer class="SimpleMarker" locked="0" enabled="1" pass="0">
+        <Option type="Map">
+          <Option value="0" name="angle" type="QString"/>
+          <Option value="227,26,28,255" name="color" type="QString"/>
+          <Option value="1" name="horizontal_anchor_point" type="QString"/>
+          <Option value="bevel" name="joinstyle" type="QString"/>
+          <Option value="circle" name="name" type="QString"/>
+          <Option value="0,0" name="offset" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+          <Option value="MM" name="offset_unit" type="QString"/>
+          <Option value="227,26,28,255" name="outline_color" type="QString"/>
+          <Option value="solid" name="outline_style" type="QString"/>
+          <Option value="0" name="outline_width" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+          <Option value="MM" name="outline_width_unit" type="QString"/>
+          <Option value="diameter" name="scale_method" type="QString"/>
+          <Option value="2" name="size" type="QString"/>
+          <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+          <Option value="MM" name="size_unit" type="QString"/>
+          <Option value="1" name="vertical_anchor_point" type="QString"/>
+        </Option>
+        <prop v="0" k="angle"/>
+        <prop v="227,26,28,255" k="color"/>
+        <prop v="1" k="horizontal_anchor_point"/>
+        <prop v="bevel" k="joinstyle"/>
+        <prop v="circle" k="name"/>
+        <prop v="0,0" k="offset"/>
+        <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+        <prop v="MM" k="offset_unit"/>
+        <prop v="227,26,28,255" k="outline_color"/>
+        <prop v="solid" k="outline_style"/>
+        <prop v="0" k="outline_width"/>
+        <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+        <prop v="MM" k="outline_width_unit"/>
+        <prop v="diameter" k="scale_method"/>
+        <prop v="2" k="size"/>
+        <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+        <prop v="MM" k="size_unit"/>
+        <prop v="1" k="vertical_anchor_point"/>
+        <effect enabled="1" type="effectStack">
+          <effect type="dropShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="outerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="0.8" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="227,26,28,255" name="single_color" type="QString"/>
+              <Option value="3" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="0.8" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="227,26,28,255" k="single_color"/>
+            <prop v="3" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+          <effect type="drawSource">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="1" name="enabled" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerShadow">
+            <Option type="Map">
+              <Option value="13" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,0,255" name="color" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="135" name="offset_angle" type="QString"/>
+              <Option value="2" name="offset_distance" type="QString"/>
+              <Option value="MM" name="offset_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="offset_unit_scale" type="QString"/>
+              <Option value="1" name="opacity" type="QString"/>
+            </Option>
+            <prop v="13" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,0,255" k="color"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="135" k="offset_angle"/>
+            <prop v="2" k="offset_distance"/>
+            <prop v="MM" k="offset_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+          <effect type="innerGlow">
+            <Option type="Map">
+              <Option value="0" name="blend_mode" type="QString"/>
+              <Option value="2.645" name="blur_level" type="QString"/>
+              <Option value="MM" name="blur_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="blur_unit_scale" type="QString"/>
+              <Option value="0,0,255,255" name="color1" type="QString"/>
+              <Option value="0,255,0,255" name="color2" type="QString"/>
+              <Option value="0" name="color_type" type="QString"/>
+              <Option value="0" name="discrete" type="QString"/>
+              <Option value="2" name="draw_mode" type="QString"/>
+              <Option value="0" name="enabled" type="QString"/>
+              <Option value="0.5" name="opacity" type="QString"/>
+              <Option value="gradient" name="rampType" type="QString"/>
+              <Option value="255,255,255,255" name="single_color" type="QString"/>
+              <Option value="2" name="spread" type="QString"/>
+              <Option value="MM" name="spread_unit" type="QString"/>
+              <Option value="3x:0,0,0,0,0,0" name="spread_unit_scale" type="QString"/>
+            </Option>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2.645" k="blur_level"/>
+            <prop v="MM" k="blur_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="blur_unit_scale"/>
+            <prop v="0,0,255,255" k="color1"/>
+            <prop v="0,255,0,255" k="color2"/>
+            <prop v="0" k="color_type"/>
+            <prop v="0" k="discrete"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="0" k="enabled"/>
+            <prop v="0.5" k="opacity"/>
+            <prop v="gradient" k="rampType"/>
+            <prop v="255,255,255,255" k="single_color"/>
+            <prop v="2" k="spread"/>
+            <prop v="MM" k="spread_unit"/>
+            <prop v="3x:0,0,0,0,0,0" k="spread_unit_scale"/>
+          </effect>
+        </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+  </symbols>
+  <colorramps/>
+  <textformats/>
+  <labelsettings/>
+  <legendpatchshapes/>
+  <symbols3d/>
+</qgis_style>


### PR DESCRIPTION
- update Punktstile rot und grün
- füge Stildatenbank "Change Detection" hinzu

![grafik](https://user-images.githubusercontent.com/20856381/123386940-7c78c680-d597-11eb-853d-7c0ec6becebc.png)


Wenn die Zeicheneffekte für die Punktstile direkt auf das Symbol gesetzt werden, werden diese vom Algorithmus _Stildatenbank aus Projekt erzeugen_  auch in der Stildatenbank angezeigt.

So kann bei eventuellen Stiländerungen leicht eine aktualisierte Stildatenbank erstellt werden, so dass es Sinn macht, diese zusätzlich zu den `.qml` Dateien bereit zu stellen.
