### PR TITLE
Füge (*) dem Modellnamen hinzu

### DIFF
--- a/models/_Centerpoint_Koordinaten_erzeugen.model3
+++ b/models/_Centerpoint_Koordinaten_erzeugen.model3
@@ -195,7 +195,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option type="QString" name="model_group" value=""/>
-  <Option type="QString" name="model_name" value="_Centerpoint_Koordinaten_erzeugen"/>
+  <Option type="QString" name="model_name" value="Centerpoint Koordinaten erzeugen (*)"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="Inputlayer">
       <Option type="List" name="data_types">

--- a/models/_Join_mit_Rest.model3
+++ b/models/_Join_mit_Rest.model3
@@ -285,7 +285,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option value="" name="model_group" type="QString"/>
-  <Option value="_Join_mit_Rest" name="model_name" type="QString"/>
+  <Option value="Join mit Rest (*)" name="model_name" type="QString"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="InputLayer1" type="Map">
       <Option name="data_types" type="List">

--- a/models/_kreisgrenze_viersen.model3
+++ b/models/_kreisgrenze_viersen.model3
@@ -170,7 +170,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option type="QString" value="" name="model_group"/>
-  <Option type="QString" value="Kreisgrenze Viersen" name="model_name"/>
+  <Option type="QString" value="Kreisgrenze Viersen (*)" name="model_name"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="native:extractbyattribute_1:Kreisgrenze Viersen">
       <Option type="bool" value="true" name="create_by_default"/>

--- a/models/_osm_editor_url.model3
+++ b/models/_osm_editor_url.model3
@@ -366,7 +366,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option type="QString" value="" name="model_group"/>
-  <Option type="QString" value="OSM Editor URL" name="model_name"/>
+  <Option type="QString" value="OSM Editor URL (*)" name="model_name"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="Input">
       <Option type="List" name="data_types">

--- a/models/_puffer_in_projekteinheit.model3
+++ b/models/_puffer_in_projekteinheit.model3
@@ -241,7 +241,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option name="model_group" type="QString" value=""/>
-  <Option name="model_name" type="QString" value="Puffer in Projekteinheit"/>
+  <Option name="model_name" type="QString" value="Puffer in Projekteinheit (*)"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="AbstandinProjektKBSEinheit" type="Map">
       <Option name="data_type" type="int" value="1"/>

--- a/models/_zaehle_kleines_im_grossen.model3
+++ b/models/_zaehle_kleines_im_grossen.model3
@@ -196,7 +196,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option type="QString" name="model_group" value=""/>
-  <Option type="QString" name="model_name" value="zähle Kleines im Großen"/>
+  <Option type="QString" name="model_name" value="zähle Kleines im Großen (*)"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="groe">
       <Option type="List" name="data_types">

--- a/models/analytisch_zusammenfuegen/_az_alles.model3
+++ b/models/analytisch_zusammenfuegen/_az_alles.model3
@@ -134,7 +134,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option type="QString" name="model_group" value="analytisch zusammenfügen (az)"/>
-  <Option type="QString" name="model_name" value="alles (az)"/>
+  <Option type="QString" name="model_name" value="alles (az) (*)"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="EingabeLayer">
       <Option type="List" name="data_types">

--- a/models/analytisch_zusammenfuegen/_az_attribut.model3
+++ b/models/analytisch_zusammenfuegen/_az_attribut.model3
@@ -130,7 +130,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option type="QString" name="model_group" value="analytisch zusammenfügen (az)"/>
-  <Option type="QString" name="model_name" value="Attribut (az)"/>
+  <Option type="QString" name="model_name" value="Attribut (az) (*)"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="EingabeLayer">
       <Option type="List" name="data_types">

--- a/models/analytisch_zusammenfuegen/_az_attribut_beruehrt.model3
+++ b/models/analytisch_zusammenfuegen/_az_attribut_beruehrt.model3
@@ -170,7 +170,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option value="analytisch zusammenfügen (az)" name="model_group" type="QString"/>
-  <Option value="Attribut und berührt (az)" name="model_name" type="QString"/>
+  <Option value="Attribut und berührt (az) (*)" name="model_name" type="QString"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="EingabeLayer" type="Map">
       <Option name="data_types" type="List">

--- a/models/analytisch_zusammenfuegen/_az_beruehrt.model3
+++ b/models/analytisch_zusammenfuegen/_az_beruehrt.model3
@@ -174,7 +174,7 @@
   </Option>
   <Option name="modelVariables"/>
   <Option type="QString" name="model_group" value="analytisch zusammenfügen (az)"/>
-  <Option type="QString" name="model_name" value="berührt (az)"/>
+  <Option type="QString" name="model_name" value="berührt (az) (*)"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="EingabeLayer">
       <Option type="List" name="data_types">

--- a/models/wfs_daten_kvie/_alle_flurstuecke_kvie.model3
+++ b/models/wfs_daten_kvie/_alle_flurstuecke_kvie.model3
@@ -688,7 +688,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option name="model_group" type="QString" value="WFS Daten"/>
-  <Option name="model_name" type="QString" value="alle Flurstücke KVIE"/>
+  <Option name="model_name" type="QString" value="alle Flurstücke KVIE (*)"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="Kommunen" type="Map">
       <Option name="allow_multiple" type="bool" value="true"/>

--- a/models/wfs_daten_kvie/_alle_gebaeude_kvie.model3
+++ b/models/wfs_daten_kvie/_alle_gebaeude_kvie.model3
@@ -739,7 +739,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option value="WFS Daten" type="QString" name="model_group"/>
-  <Option value="alle Gebäude KVIE" type="QString" name="model_name"/>
+  <Option value="alle Gebäude KVIE (*)" type="QString" name="model_name"/>
   <Option type="Map" name="parameterDefinitions">
     <Option type="Map" name="Kommunen">
       <Option value="true" type="bool" name="allow_multiple"/>

--- a/models/wfs_daten_kvie/_alle_navigeb_kvie.model3
+++ b/models/wfs_daten_kvie/_alle_navigeb_kvie.model3
@@ -688,7 +688,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option name="model_group" type="QString" value="WFS Daten"/>
-  <Option name="model_name" type="QString" value="alle NaviGeb KVIE"/>
+  <Option name="model_name" type="QString" value="alle NaviGeb KVIE (*)"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="Kommunen" type="Map">
       <Option name="allow_multiple" type="bool" value="true"/>

--- a/models/wfs_daten_kvie/_alle_nutzungsarten_kvie.model3
+++ b/models/wfs_daten_kvie/_alle_nutzungsarten_kvie.model3
@@ -255,7 +255,7 @@
   <Option name="help"/>
   <Option name="modelVariables"/>
   <Option name="model_group" type="QString" value="WFS Daten"/>
-  <Option name="model_name" type="QString" value="alle Nutzungsarten KVIE"/>
+  <Option name="model_name" type="QString" value="alle Nutzungsarten KVIE (*)"/>
   <Option name="parameterDefinitions" type="Map">
     <Option name="native:deletecolumn_1:alle Nutzungsarten KVIE" type="Map">
       <Option name="create_by_default" type="bool" value="true"/>


### PR DESCRIPTION
Um in der Werkzeugkiste Modelle in der Verteilung besser von anderen Modellen unterscheiden zu können.