### PR TITLE
Analytisch zusammenfügen: Erlaube jeden Datentyp für Attribute ...

### DIFF
--- a/models/analytisch_zusammenfuegen/az_attribut_beruehrt_mit_anzahl.model3
+++ b/models/analytisch_zusammenfuegen/az_attribut_beruehrt_mit_anzahl.model3
@@ -339,7 +339,7 @@
     </Option>
     <Option type="Map" name="NurGeometrienmitfolgendenAttributenzusammenfgen">
       <Option type="bool" name="allow_multiple" value="true"/>
-      <Option type="int" name="data_type" value="1"/>
+      <Option type="int" name="data_type" value="-1"/>
       <Option type="invalid" name="defaultGui"/>
       <Option type="bool" name="default_to_all_fields" value="false"/>
       <Option type="QString" name="description" value="Nur Geometrien mit folgenden Attributen zusammenfügen"/>

--- a/models/analytisch_zusammenfuegen/az_attribut_mit_anzahl.model3
+++ b/models/analytisch_zusammenfuegen/az_attribut_mit_anzahl.model3
@@ -299,7 +299,7 @@
     </Option>
     <Option type="Map" name="NurGeometrienmitfolgendenAttributenzusammenfgen">
       <Option type="bool" value="true" name="allow_multiple"/>
-      <Option type="int" value="1" name="data_type"/>
+      <Option type="int" value="-1" name="data_type"/>
       <Option type="invalid" name="defaultGui"/>
       <Option type="bool" value="false" name="default_to_all_fields"/>
       <Option type="QString" value="Nur Geometrien mit folgenden Attributen zusammenfügen" name="description"/>


### PR DESCRIPTION
... vorher war nur der Datentyp "Zeichenkette" erlaubt.